### PR TITLE
Updated PRINT_START macro template variable syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,10 +941,10 @@ gcode:
     
     G28
     # <insert your routines here>
-    M190 S{bedtemp}                                                              ; set & wait for bed temp
-    TEMPERATURE_WAIT SENSOR="temperature_sensor chamber" MINIMUM={chambertemp}   ; wait for chamber temp
+    M190 S{params.BED}                                                              ; set & wait for bed temp
+    TEMPERATURE_WAIT SENSOR="temperature_sensor chamber" MINIMUM={params.CHAMBER}   ; wait for chamber temp
     # <insert your routines here>
-    M109 S{hotendtemp}                                                           ; set & wait for hotend temp
+    M109 S{params.HOTEND}                                                           ; set & wait for hotend temp
     # <insert your routines here>
     G28 Z                                                                        ; final z homing
 ```


### PR DESCRIPTION
I updated the PRINT_START macro template to use params.VARIABLE syntax since the current template format was giving me errors when trying to print.

Macro variable syntax is based on this tutorial: https://klipper.discourse.group/t/macro-creation-tutorial/30/4