### PR TITLE
Update pressure_advance.md for Voron 0

### DIFF
--- a/articles/pressure_advance.md
+++ b/articles/pressure_advance.md
@@ -68,6 +68,9 @@ This method is quicker to run and more precise than the [:pushpin:tower method](
     - **PA Stepping:**:
         - **Direct Drive**: 0.005
         - **Bowden***: 0.05
+    - **Test Line Spacing:**
+        - **Voron 0 (120mm bed)**: 4
+        - **Default**: 5
     - **Print Anchor Frame**: Checked
 - **Advanced**
     - **Nozzle Line Ratio**: 1.2


### PR DESCRIPTION
Update instructions to override the default line spacing of 5 with 4 so that the test fits on a Voron 0 bed