### PR TITLE
Optional filters for DUMP_PARAMETERS macro

### DIFF
--- a/articles/useful_macros.md
+++ b/articles/useful_macros.md
@@ -414,27 +414,96 @@ name: Shut down
 gcode: SHUTDOWN
 ```
 
-# Dump Parameters
-This dumps all Klipper parameters to the g-code terminal. This helps to find Klipper system variables for use in macros. A filter for both name and value can be applied.
+# Dump Variables
+This dumps all Klipper variables to the g-code terminal. This helps to find Klipper system variables for use in macros. A filter for both name and value can be applied.
 ```
-[gcode_macro DUMP_PARAMETERS]
+[gcode_macro DUMP_VARIABLES]
 gcode:
-    {% set filter_name = params.FILTER_NAME|default('')|string|lower %}
-    {% set filter_value = params.FILTER_VALUE|default('')|string|lower %}
+    {% set filter_name = params.NAME|default('')|string|lower %}
+    {% set filter_value = params.VALUE|default('')|string|lower %}
     {% set show_cfg = params.SHOW_CFG|default(0)|int %}
+    
+    {% set out = [] %}
 
-    {% for name1 in printer %}
-        {% for name2 in printer[name1] %}
-            {% if (show_cfg or not ((name1|lower) == 'configfile' and (name2|lower) in ['config', 'settings'])) and ((filter_name == '' and filter_value == '') or (filter_name != '' and filter_value == '' and (filter_name in (name1|lower) or filter_name in (name2|lower))) or (filter_name == '' and filter_value != '' and filter_value in (printer[name1][name2]|string|lower)) or (filter_name != '' and filter_value != '' and (filter_name in (name1|lower) or filter_name in (name2|lower)) and filter_value in (printer[name1][name2]|string|lower))) %}
-                { action_respond_info("printer['%s'].%s = %s" % (name1, name2, printer[name1][name2])) }
+    {% for key1 in printer %}
+        {% for key2 in printer[key1] %}
+            {% if (show_cfg or not (key1|lower == 'configfile' and key2|lower in ['config', 'settings'])) and (filter_name in key1|lower or filter_name in key2|lower) and filter_value in printer[key1][key2]|string|lower %}
+                {% set dummy = out.append("printer['%s'].%s = %s" % (key1, key2, printer[key1][key2])) %}
             {% endif %}
         {% else %}
-            {% if (filter_name == '' and filter_value == '') or (filter_name != '' and filter_value == '' and filter_name in (name1|lower)) or (filter_name == '' and filter_value != '' and filter_value in (printer[name1]|string|lower)) or (filter_name != '' and filter_value != '' and filter_name in (name1|lower) and filter_value in (printer[name1]|string|lower)) %}
-                { action_respond_info("printer['%s'] = %s" % (name1, printer[name1])) }
+            {% if filter_name in key1|lower and filter_value in printer[key1]|string|lower %}
+                {% set dummy = out.append("printer['%s'] = %s" % (key1, printer[key1])) %}
             {% endif %}
         {% endfor %}
     {% endfor %}
+    
+    {action_respond_info(out|join("\n"))}
 ```
+
+Usage:
+- `DUMP_VARIABLES`: Returns all variables (excluding `printer['configfile'].config` and `printer['configfile'].settings` as they contain the entire config).
+- `DUMP_VARIABLES NAME=stepper`: Returns all variables which have the string `stepper` in their name.
+- `DUMP_VARIABLES VALUE=extruder` : Returns all variables which have the string `extruder` in their value.
+- `DUMP_VARIABLES NAME=stepper VALUE=extruder` : Returns all variables which have the string `stepper` in their name and the string `extruder` in their value.
+- `DUMP_VARIABLES SHOW_CFG=1` : Returns all variables.
+
+# Get Variable
+This returns value and type of a single variable to the g-code terminal. Keys and indexes can be chained to access nested dictionaries and lists.
+```
+    {% set names = (params.NAME).split('.')|list %}
+    {% set join = (params.JOIN)|default(1)|int %}
+    
+    {% set _dummy0 = namespace( break = 0 ) %}
+    {% set _dummy1 = namespace( out = printer[names|first] ) %}
+    
+    {% for name in names if _dummy0.break == 0 %}
+        {% if loop.index > 1 %}
+            {% if name in _dummy1.out %}
+                {% set _dummy1.out = _dummy1.out[name] %}
+            {% elif name[0] in '0123456789' and _dummy1.out is iterable and _dummy1.out is not string and _dummy1.out is not mapping and _dummy1.out|length > name[0]|int %}
+                {% set _dummy1.out = _dummy1.out[name|int] %}
+            {% else %}
+                {% set _dummy0.break = loop.index0 %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+    
+    {% if _dummy1.out is boolean %}
+        { action_respond_info('Type: boolean') }
+    {% elif _dummy1.out is float %}
+        { action_respond_info('Type: float') }
+    {% elif _dummy1.out is integer %}
+        { action_respond_info('Type: integer') }
+    {% elif _dummy1.out is mapping %}
+        { action_respond_info('Type: mapping') }
+    {% elif _dummy1.out is string %}
+        { action_respond_info('Type: string') }
+    {% elif _dummy1.out is iterable %}
+        { action_respond_info('Type: iterable') }
+    {% elif _dummy1.out is none %}
+        { action_respond_info('Type: none') }
+    {% elif _dummy1.out is undefined %}
+        { action_respond_info('Type: undefined') }
+    {% elif _dummy1.out is callable %}
+        { action_respond_info('Type: callable') }
+    {% else %}
+        { action_respond_info('Type: unknown') }
+    {% endif %}
+    
+    {% if join and _dummy1.out is iterable and _dummy1.out is not string and _dummy1.out is not mapping %}
+        { action_respond_info('%s' % _dummy1.out|join("\n")) }
+    {% else %}
+        { action_respond_info('%s' % _dummy1.out) }
+    {% endif %}
+    
+    {% if _dummy0.break != 0 %}
+        { action_respond_info('"printer.%s" does not contain "%s"!' % (names[0:_dummy0.break]|join('.'), names[_dummy0.break])) }
+    {% endif %}
+```
+
+Usage:
+- `GET_VARIABLE NAME=toolhead`: Returns value and type of variable `printer.toolhead`.
+- `GET_VARIABLE NAME=bed_mesh.profiles.default.points.1.0`: Returns value and type of variable `printer.bed_mesh.profiles.default.points[1][0]`.
 
 # Replace `M109`/`M190` With `TEMPERATURE_WAIT`
 Replace `M109` (wait for hotend temperature) and `M190` (wait for bed temperature) with TEMPERATURE_WAIT.


### PR DESCRIPTION
Adding optional name and value filters to the `DUMP_PARAMETERS` macro.
This also hides the clutter that `['configfile'].config` and `['configfile'].settings` cause in the console by default (can be disabled by calling the macro with `SHOW_CFG=1`).
Should make debugging easier and faster.
Tested on my V2.4r2 running MainsailOS.