### PR TITLE
Update small_infill_areas_overextruded.md

### DIFF
--- a/articles/troubleshooting/small_infill_areas_overextruded.md
+++ b/articles/troubleshooting/small_infill_areas_overextruded.md
@@ -40,7 +40,7 @@ But, there are some things that *may* help a bit:
     - **There seem to be diminishing returns here**, at least in my testing. There's no need to tune this down as low as physically possible.
 - Try reducing top infill speeds and accelerations.
     - Again, there are diminishing returns here. On my printer, I stop seeing noticeable improvements below around 2k acceleration. Your mileage may vary.
-- Ensure that your extruder gears don't have too much [:page_facing_up: backlash](https://gfycat.com/mealycautiouscoqui). 
+- Ensure that your extruder gears don't have too much [:page_facing_up: backlash](https://i.gifer.com/N4k2.gif). 
     - You **want** a tiny amount of backlash (but as little as possible - this is just to make sure that you haven't over tensioned the gears. Too much tension can cause [:page_facing_up: extrusion patterns](../troubleshooting/extrusion_patterns.md) and accelerated wear.) 
     - Too much backlash can cause issues with pressure advance and retractions.
     - You may need to re-tune PA (and sometimes esteps) after adjusting this.


### PR DESCRIPTION
The link to gifycat for the backlash visualization is dead. They closed up shop in June 2023. I Pulled the file on wayback machine and found a match on another gif site.  Gifer.com's TOS says just not to hotlink adult content so I believe this could work if you don't want to host it.  [This could work as well](http://cnczone.com/gallery/data/500/2793backlash.gif).  I have attached the original animated mp4 from gifycat and a copy of it converted to gif below. 

Cheers

![Backlash](https://github.com/AndrewEllis93/Print-Tuning-Guide/assets/74942764/9d86511c-1161-459d-a428-d04a0779ffa5)

https://github.com/AndrewEllis93/Print-Tuning-Guide/assets/74942764/4ba46482-ea5b-411b-a59f-03d8caa4b6aa

