### PR TITLE
added an OpenSCAD version and python script to generate em_cube.stl f…

### DIFF
--- a/test_prints/extrusion_multiplier_cubes/labeled/source/openscad/README.md
+++ b/test_prints/extrusion_multiplier_cubes/labeled/source/openscad/README.md
@@ -1,0 +1,44 @@
+
+To use the python script yout have to install python-click and python-numpy. 
+
+
+```
+Usage: em_cube.py [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  generate        generate a em_cube.stl
+  generate-cubes  A script to generate multiple extrusion multiplier cubes
+
+
+```
+
+```
+Usage: em_cube.py generate [OPTIONS] LABEL
+
+  generate a em_cube.stl
+
+Options:
+  --cube-width FLOAT    width of the cube
+  --cube-depth FLOAT    depth of the cube
+  --cube-height FLOAT   height of the cube
+  --text-size FLOAT     text size of the label
+  --layer-height FLOAT  layer height
+  --help                Show this message and exit.
+```
+
+```
+Usage: em_cube.py generate-cubes [OPTIONS] [EM_START] [EM_END] [EM_INTERVAL]
+
+  A script to generate multiple extrusion multiplier cubes
+
+Options:
+  --cube-width FLOAT    width of the cube
+  --cube-depth FLOAT    depth of the cube
+  --cube-height FLOAT   height of the cube
+  --text-size FLOAT     text size of the label
+  --layer-height FLOAT  layer height
+  --help                Show this message and exit.
+```

--- a/test_prints/extrusion_multiplier_cubes/labeled/source/openscad/em_cube.py
+++ b/test_prints/extrusion_multiplier_cubes/labeled/source/openscad/em_cube.py
@@ -16,7 +16,7 @@ def cli():
 def generate_cube(cube_width, cube_depth, cube_height, layer_height, label, text_size):
    command = [
         'openscad', 'em_cube.scad',
-        '-D', f'em_value={label}',
+        '-D', f'em_value="{label}"',
         '-D', f'cube_width={cube_width:.3f}',
         '-D', f'cube_depth={cube_depth:.3f}',
         '-D', f'cube_height={cube_height:.3f}',
@@ -26,8 +26,9 @@ def generate_cube(cube_width, cube_depth, cube_height, layer_height, label, text
         '--export-format', 'binstl',
         ]
    result = subprocess.run(command, capture_output=True)
-   print(f'openscad ..... -D em_value="{label}" -o em_cube_{label}.stl .....') 
-   print(result)
+   #print(f'openscad ..... -D em_value="{label}" -o em_cube_{label}.stl .....') 
+   print(*command)
+   #print(result)
  
 
 @click.command('generate')

--- a/test_prints/extrusion_multiplier_cubes/labeled/source/openscad/em_cube.py
+++ b/test_prints/extrusion_multiplier_cubes/labeled/source/openscad/em_cube.py
@@ -1,0 +1,64 @@
+# coding: utf-8
+
+##
+# install python-click, python-numpy and openscad to use this script
+#
+
+import subprocess
+import numpy as np
+import click 
+
+@click.group()
+def cli():
+    pass
+
+
+def generate_cube(cube_width, cube_depth, cube_height, layer_height, label, text_size):
+   command = [
+        'openscad', 'em_cube.scad',
+        '-D', f'em_value={label}',
+        '-D', f'cube_width={cube_width:.3f}',
+        '-D', f'cube_depth={cube_depth:.3f}',
+        '-D', f'cube_height={cube_height:.3f}',
+        '-D', f'layer_height={layer_height:.3f}',
+        '-D', f'text_size={text_size:.1f}',
+        '-o', f'em_cube_{label}.stl',
+        '--export-format', 'binstl',
+        ]
+   result = subprocess.run(command, capture_output=True)
+   print(f'openscad ..... -D em_value="{label}" -o em_cube_{label}.stl .....') 
+   print(result)
+ 
+
+@click.command('generate')
+@click.option('--cube-width', default=30.0, type=float, help='width of the cube')
+@click.option('--cube-depth', default=30.0, type=float, help='depth of the cube')
+@click.option('--cube-height', default=3.0, type=float, help='height of the cube')
+@click.option('--text-size', default=6, type=float, help='text size of the label')
+@click.option('--layer-height', default=0.2, type=float, help='layer height')
+@click.argument('label', type=str)
+def generate_cube_subcmd(cube_width, cube_depth, cube_height, layer_height, label, text_size) :
+    """ generate a em_cube.stl"""
+    generate_cube(cube_width, cube_depth, cube_height, layer_height, label, text_size)
+ 
+@click.command()
+@click.argument('em_start', type=float, default=0.85)
+@click.argument('em_end', default=1.05)
+@click.argument('em_interval', default=0.01)
+@click.option('--cube-width', default=30.0, type=float, help='width of the cube')
+@click.option('--cube-depth', default=30.0, type=float, help='depth of the cube')
+@click.option('--cube-height', default=3.0, type=float, help='height of the cube')
+@click.option('--text-size', default=6, type=float, help='text size of the label')
+@click.option('--layer-height', default=0.2, type=float, help='layer height')
+def generate_cubes(em_start, em_end, em_interval, cube_width, cube_depth, cube_height, layer_height, text_size):
+    """A script to generate multiple extrusion multiplier cubes"""
+    for em_value in np.arange(em_start, em_end, em_interval ):
+        generate_cube(cube_width, cube_depth, cube_height, layer_height, str(f'{em_value:.3f}'), text_size)
+
+
+cli.add_command(generate_cubes)
+cli.add_command(generate_cube_subcmd)
+
+
+if __name__ == '__main__':
+    cli()

--- a/test_prints/extrusion_multiplier_cubes/labeled/source/openscad/em_cube.scad
+++ b/test_prints/extrusion_multiplier_cubes/labeled/source/openscad/em_cube.scad
@@ -1,0 +1,23 @@
+// the label printed to the part
+em_value = "0.921";
+
+text_size = 6.5;
+text_font = "comic";
+// layer height you are printing the em_cubes
+layer_height = 0.2;
+
+// width of the cube
+cube_width = 30;
+// depth of the cube
+cube_depth = 30;
+// height of the cube
+cube_height = 3;
+
+difference() {
+	translate([-(cube_width/2), -(cube_depth/2), 0])
+		cube([cube_width, cube_depth, cube_height]);
+	translate([0,0,-layer_height])
+		linear_extrude(layer_height*2)
+			mirror([1,0,0])
+				text(em_value, size = text_size, halign = "center", valign = "center");
+}


### PR DESCRIPTION
…iles

Hi I am mostly on Linux and needed a way to create fine grain test cubes it is such a simple model. I decided to recreate the CAD model in openscad. I added a script (python) to generate multiple labeled cubes. This should work on most Linux systems (I only tested Arch).

