### PR TITLE
Use MINIMUM_CRUISE_RATIO on new klipper instances

### DIFF
--- a/macros/TEST_SPEED.cfg
+++ b/macros/TEST_SPEED.cfg
@@ -63,7 +63,12 @@ gcode:
     G0 X{x_min} Y{y_min} Z{bound + 10} F{speed*60}
 
     # Set new limits
-    SET_VELOCITY_LIMIT VELOCITY={speed} ACCEL={accel} MINIMUM_CRUISE_RATIO=0.5
+    {% if printer.configfile.settings.printer.minimum_cruise_ratio is defined %}
+        SET_VELOCITY_LIMIT VELOCITY={speed} ACCEL={accel} MINIMUM_CRUISE_RATIO=0.5
+    {% else %}
+        SET_VELOCITY_LIMIT VELOCITY={speed} ACCEL={accel} ACCEL_TO_DECEL={accel / 2}
+    {% endif %}
+    
 
     {% for i in range(iterations) %}
         # Large pattern diagonals
@@ -96,8 +101,12 @@ gcode:
     {% endfor %}
 
     # Restore max speed/accel/accel_to_decel to their configured values
-    SET_VELOCITY_LIMIT VELOCITY={printer.configfile.settings.printer.max_velocity} ACCEL={printer.configfile.settings.printer.max_accel} MINIMUM_CRUISE_RATIO={printer.configfile.settings.printer.minimum_cruise_ratio} 
-
+    {% if printer.configfile.settings.printer.minimum_cruise_ratio is defined %}
+        SET_VELOCITY_LIMIT VELOCITY={printer.configfile.settings.printer.max_velocity} ACCEL={printer.configfile.settings.printer.max_accel} MINIMUM_CRUISE_RATIO={printer.configfile.settings.printer.minimum_cruise_ratio} 
+    {% else %}
+        SET_VELOCITY_LIMIT VELOCITY={printer.configfile.settings.printer.max_velocity} ACCEL={printer.configfile.settings.printer.max_accel} ACCEL_TO_DECEL={printer.configfile.settings.printer.max_accel_to_decel}
+    {% endif %}
+    
     # Re-home and get position again for comparison:
         M400 # Finish moves - https://github.com/AndrewEllis93/Print-Tuning-Guide/issues/66
         G28 # This is a full G28 to fix an issue with CoreXZ - https://github.com/AndrewEllis93/Print-Tuning-Guide/issues/12

--- a/macros/TEST_SPEED.cfg
+++ b/macros/TEST_SPEED.cfg
@@ -63,7 +63,7 @@ gcode:
     G0 X{x_min} Y{y_min} Z{bound + 10} F{speed*60}
 
     # Set new limits
-    SET_VELOCITY_LIMIT VELOCITY={speed} ACCEL={accel} ACCEL_TO_DECEL={accel / 2}
+    SET_VELOCITY_LIMIT VELOCITY={speed} ACCEL={accel} MINIMUM_CRUISE_RATIO=0.5
 
     {% for i in range(iterations) %}
         # Large pattern diagonals
@@ -96,7 +96,7 @@ gcode:
     {% endfor %}
 
     # Restore max speed/accel/accel_to_decel to their configured values
-    SET_VELOCITY_LIMIT VELOCITY={printer.configfile.settings.printer.max_velocity} ACCEL={printer.configfile.settings.printer.max_accel} ACCEL_TO_DECEL={printer.configfile.settings.printer.max_accel_to_decel} 
+    SET_VELOCITY_LIMIT VELOCITY={printer.configfile.settings.printer.max_velocity} ACCEL={printer.configfile.settings.printer.max_accel} MINIMUM_CRUISE_RATIO={printer.configfile.settings.printer.minimum_cruise_ratio} 
 
     # Re-home and get position again for comparison:
         M400 # Finish moves - https://github.com/AndrewEllis93/Print-Tuning-Guide/issues/66


### PR DESCRIPTION
Changing max_accel_to_decel to the new minimum_cruise_ratio instead.  I did it as a conditional based on the printer config so it should be backward compatible. 