### PR TITLE
Update link to MihaiDesigns inconsistent extrusion test

### DIFF
--- a/articles/troubleshooting/extrusion_patterns.md
+++ b/articles/troubleshooting/extrusion_patterns.md
@@ -39,7 +39,7 @@ The right cube was printed after adjusting [:pushpin: extruder backlash](#extrud
     - [![](./images/extrusion_patterns/Backlash-Pattern.png)](./images/extrusion_patterns/Backlash-Pattern.png){:target="_blank"}
 
 ## Test Prints
-See the [:page_facing_up: test prints from MihaiDesigns](https://mihaidesigns.com/pages/inconsistent-extrusion-test)
+See the [:page_facing_up: test prints from MihaiDesigns](https://mihaidesigns.com/inconsistent-extrusion/)
 
 ## External Perimeters First
 


### PR DESCRIPTION
The original link is broken (can still be found in the [wayback machine](https://web.archive.org/web/20210426232122/http://mihaidesigns.com/pages/inconsistent-extrusion-test))

The new link is https://mihaidesigns.com/inconsistent-extrusion/


Perhaps https://mihaidesigns.com/motor-vibration-test/ too