### PR TITLE
Add pressure advance prereqs from introduction to all sub-pages

### DIFF
--- a/articles/pressure_linear_advance/lines_method_deprecated.md
+++ b/articles/pressure_linear_advance/lines_method_deprecated.md
@@ -21,6 +21,10 @@ grand_parent: Tuning
 {: .compat}
 :dizzy: This page is compatible with Klipper and Marlin.
 
+{: .prereqs}
+> - You should [:page_facing_up: calibrate your extruder](https://docs.vorondesign.com/build/startup/#extruder-calibration-e-steps) first.
+> - ![]({{ "/assets/img/marlin_small.png" | absolute_url }}) **Marlin**: Linear advance must be [:page_facing_up: enabled in firmware](https://marlinfw.org/docs/configuration/configuration.html#linear-advance). Not all printers have it enabled by default. 
+
 ---
 
 - :warning: This has been deprecated in favor of my new pressure advance tuning tool! See [:page_facing_up: here](./pattern_method.md).

--- a/articles/pressure_linear_advance/pattern_method.md
+++ b/articles/pressure_linear_advance/pattern_method.md
@@ -19,6 +19,10 @@ grand_parent: Tuning
 {: .compat}
 :dizzy: This page is compatible with Klipper, Marlin, and RepRapFirmware.
 
+{: .prereqs}
+> - You should [:page_facing_up: calibrate your extruder](https://docs.vorondesign.com/build/startup/#extruder-calibration-e-steps) first.
+> - ![]({{ "/assets/img/marlin_small.png" | absolute_url }}) **Marlin**: Linear advance must be [:page_facing_up: enabled in firmware](https://marlinfw.org/docs/configuration/configuration.html#linear-advance). Not all printers have it enabled by default. 
+
 ---
 
 **Visit my [:page_facing_up: calibration tool](https://ellis3dp.com/Pressure_Linear_Advance_Tool/).**

--- a/articles/pressure_linear_advance/saving.md
+++ b/articles/pressure_linear_advance/saving.md
@@ -19,6 +19,9 @@ grand_parent: Tuning
 {: .compat}
 :dizzy: This page is compatible with Klipper, Marlin, and RepRapFirmware.
 
+{: .prereqs}
+> - ![]({{ "/assets/img/marlin_small.png" | absolute_url }}) **Marlin**: Linear advance must be [:page_facing_up: enabled in firmware](https://marlinfw.org/docs/configuration/configuration.html#linear-advance). Not all printers have it enabled by default. 
+
 ---
 
 ![]({{ "/assets/img/klipper.png" | absolute_url }})


### PR DESCRIPTION
I came to your guide from OrcaSlicer own tutorial and missed the introduction prerequisites that marlin firmware must be enabled. So, I think adding the pre requisites to all sub-pages will help user if linked directly from another site.