### PR TITLE
Update TEST_SPEED To Account For Negative Minimums

### DIFF
--- a/macros/TEST_SPEED.cfg
+++ b/macros/TEST_SPEED.cfg
@@ -22,9 +22,19 @@ gcode:
     
     # Large pattern
         # Max positions, inset by BOUND
-        {% set x_min = printer.toolhead.axis_minimum.x + bound %}
+        {% set x_min = printer.toolhead.axis_minimum.x %}
+        {% if x_min < 0 %}
+            {% set x_min = 0 %}
+        {% endif %}
+    
+        {% set y_min = printer.toolhead.axis_minimum.y %}
+        {% if y_min < 0 %}
+            {% set y_min = 0 %}
+        {% endif %}
+    
+        {% set x_min = x_min + bound %}
         {% set x_max = printer.toolhead.axis_maximum.x - bound %}
-        {% set y_min = printer.toolhead.axis_minimum.y + bound %}
+        {% set y_min = y_min + bound %}
         {% set y_max = printer.toolhead.axis_maximum.y - bound %}
     
     # Small pattern at center


### PR DESCRIPTION
It's not uncommon for printers to have a negative `position_min`.  If you have a negative, the bounds of the Large moves may still be outside the bed moves. This is especially true if you have `position_min` incorrectly set at an excessively negative and incorrect amount.  This will cause the moves to still ram into the frame (...ask me how I know...).

This change forces it to use the lesser of the two values, zero or the `position_min`, causing it to be over the bed and preventing slams due to misconfiguration.