### PR TITLE
Adding Post-Test Park

### DIFF
--- a/macros/TEST_SPEED.cfg
+++ b/macros/TEST_SPEED.cfg
@@ -129,6 +129,14 @@ gcode:
         G4 P1000 
         GET_POSITION
 
+    # Park Nozzle After Testing - Use `SAVE_VARIABLE VARIABLE=test_speed_park_{x,y} VALUE={x,y}` To Change Path
+    #   This is useful is you are using a custom homing that moves the X/Y in a positive direction.
+        {% set moveX = printer.save_variables.variables.test_speed_park_x | default(printer.toolhead.axis_maximum.x - 1) %}
+        {% set moveY = printer.save_variables.variables.test_speed_park_y | default(printer.toolhead.axis_maximum.y - 1) %}
+
+        G0 X{moveX} Y{moveY } F{30*60}
+
+
     # Restore previous gcode state (absolute/relative, etc)
     RESTORE_GCODE_STATE NAME=TEST_SPEED
     


### PR DESCRIPTION
TL;DR: Allow Post Test Parking To Prevent Ramming Due to Custom Homing

My CR-30 has `[homing_override]` defined. I've added a few mods to make it so that if it homes X first (default), it will ram into one of the bed nobs for leveling. To prevent this, I have defined a custom homing that force-moves X by +10mm before homing Y, raising Y by 20mm, and then homing X. This allows the homing to clear the leveling nob without issue. I further enhance this by ensuring that my PRINT_END and similar macros parks the nozzle close to X=0. 

The issue I ran into is that `TEST_SPEED` homes the printer, even if already homed (which I think is required). If I run multiple iterations of TEST_SPEED, the previous iteration leaves the printer at X=[max - 1]. When the home runs for the current iteration, my hotend ends up ramming. With my memory, I keep forgetting to move the gantry back a bit to account for this prior to each test.

I finally got tired of startaling myself every time I ran TEST_SPEED from the ramming, that I implemented this change. This makes it so that after the TEST_SPEED finishes, it'll park the nozzle based on the saved variables. If no saved variables exist, it stays at X=[max-1], but you can use `SAVE_VARIABLE VARIABLE=test_speed_park_x VALUE=150` and it will then move X to 150.

In this way, when the next homing is done, the gantry doesn't jam.

Note: I haven't tested this on a printer that doesn't have variables enabled, but I presume the default will handle that.